### PR TITLE
Support user & group violations, policy format change, perf improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # rbac-police <img src="./docs/logo.png" width="50">
-Retrieve the RBAC permissions of serviceAccounts, pods and nodes in a Kubernetes cluster, and evaluate them using policies written in Rego.
+Retrieve the RBAC permissions of identities (service accounts, pods, nodes, users and groups) in a Kubernetes cluster, and evaluate them using policies written in Rego.
 
-The [default policy library](./lib) includes ~20 policies that identify serviceAccounts, pods and nodes that possess risky permissions, each detecting a different attack path. See the Recommendations section [here](https://www.paloaltonetworks.com/resources/whitepapers/kubernetes-privilege-escalation-excessive-permissions-in-popular-platforms) for advice on addressing powerful permissions in Kubernetes clusters.
-
+The [policy library](./lib) includes ~20 policies that identify identities possessing risky permissions, each detecting a different attack path. See the Recommendations section [here](https://www.paloaltonetworks.com/resources/whitepapers/kubernetes-privilege-escalation-excessive-permissions-in-popular-platforms) for advice on addressing powerful permissions in Kubernetes clusters.
 
 ## Quick Start
 
@@ -27,7 +26,7 @@ The [default policy library](./lib) includes ~20 policies that identify serviceA
 3. Connect `kubectl` to a Kubernetes cluster.
 4. Evaluate RBAC permissions and identify privilege escalation paths in your cluster using the default policy library:
 
-    ```shell
+    ```
     ./rbac-police eval lib/
     ```
 
@@ -38,9 +37,15 @@ Only evaluate policies with a severity equal to or higher than a threshold.
 ./rbac-police eval lib/ -s High
 ```
 ### Scope to a namespace
-Collect and evaluate RBAC permssions in a certain namespace.
+Only look into service accounts and pods from a certain namespace.
 ```
 ./rbac-police eval lib/ -n production
+```
+### Configure violation types
+Configure which identities are evaluated for violations, default are `sa,node,combined`.
+```
+./rbac-police eval lib/ --violations sa,user
+./rbac-police eval lib/ --violations all  # sa,node,combined,user,group
 ```
 ### Only alert on SAs that exist on all nodes
 Only consider violations from service accounts that exist on all nodes. Useful for identifying violating DaemonSets.
@@ -52,7 +57,7 @@ Improve accuracy by identifying security-related features gates and admission co
 ```
 ./rbac-police eval lib/ -w
 ```
-###  Ignore control plane
+### Ignore control plane
 Ignore control plane pods and nodes in clusters that host the control plane.
 ```
 ./rbac-police eval lib/ --ignore-controlplane

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -13,7 +13,7 @@ import (
 var (
 	collectCmd = &cobra.Command{
 		Use:   "collect",
-		Short: "Collects the RBAC permissions of serviceAccounts, pods and nodes",
+		Short: "Collects the RBAC permissions of Kubernetes identities",
 		Run:   runCollect,
 	}
 )

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -23,7 +23,7 @@ func runCollect(cmd *cobra.Command, args []string) {
 	if collectResult == nil {
 		return // error printed by Collect()
 	}
-	output, err := json.MarshalIndent(collectResult, "", "    ")
+	output, err := json.Marshal(collectResult)
 	if err != nil {
 		log.Errorln("runCollect: failed to marshal results with", err)
 		return

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -15,8 +15,10 @@ import (
 var (
 	expandCmd = &cobra.Command{
 		Use:   "expand [rbac-json]",
-		Short: "Presents the RBAC permissions of serviceAccounts, pods and nodes in a human-readable format",
-		Run:   runExpand,
+		Short: "Presents the RBAC permissions of Kubernetes identities in a (more) human-readable format",
+		Long: `Presents the RBAC permissions of Kubernetes identities in a (more) human-readable format for manual drill down.
+This is done by repeating the entire permissions of each role under each identity that has it.`,
+		Run: runExpand,
 	}
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ var (
 	rootCmd = &cobra.Command{
 		Use:   "rbac-police",
 		Short: "See and evaluate RBAC permissions in Kubernetes clusters",
-		Long:  `Retrieves the RBAC permissions of serviceaccounts, pods and nodes in a Kubernetes cluster, and evaluates them using policies written in Rego.`,
+		Long:  `Retrieves the RBAC permissions of Kubernetes identities and evaluates them using policies written in Rego.`,
 	}
 )
 

--- a/docs/collect.md
+++ b/docs/collect.md
@@ -1,5 +1,5 @@
 # rbac-police collect
-Collects the RBAC permissions of serviceAccounts, pods and nodes. For clusters hosted on EKS and GKE, the `collect` command also identifies serviceaccount annotations that assign cloud provider IAM entities to Kubernetes serviceaccounts.
+Collects the RBAC permissions of Kubernetes identities. For clusters hosted on EKS and GKE, the `collect` command also identifies service account annotations that assign cloud provider IAM entities to Kubernetes service accounts.
 
 ## Help
 ```
@@ -89,6 +89,30 @@ Global Flags:
                 "kube-system:kube-dns",
             ]
         },
+    ],
+    "users": [
+        {
+            "name": "user-name",
+            "roles": [
+                {
+                    "name": "a role / clusterRole assigned to this user",
+                    "namespace": "role's namespace", // omitempty
+                    "effectiveNamespace": "if granted by a roleBinding, namespace where permissions are in effect" // omitempty
+                }
+            ]
+        }
+    ],
+    "groups": [
+        {
+            "name": "group-name",
+            "roles": [
+                {
+                    "name": "a role / clusterRole assigned to this group",
+                    "namespace": "role's namespace", // omitempty
+                    "effectiveNamespace": "if granted by a roleBinding, namespace where permissions are in effect" // omitempty
+                }
+            ]
+        }
     ],
     "roles": [
         {

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -1,5 +1,5 @@
 # rbac-police eval
-Evaulates the RBAC permissions of serviceAccounts, pods and nodes using policies written in Rego. If a RBAC permission JSON file isn't provided as an argument, `eval` internally calls [`collect`](./collect.md).
+Evaulates the RBAC permissions of Kubernetes identities using policies written in Rego. If a RBAC permission JSON file isn't provided as an argument, `eval` internally calls [`collect`](./collect.md).
 
 See [policies.md](./policies.md) for the list of built-in policies and for instructions on creating new ones. The built-in policy library aim to identify privilege escaltion paths in a cluster.
 
@@ -13,12 +13,10 @@ Flags:
   -d, --debug                        debug mode, prints debug info and stdout of policies
   -h, --help                         help for eval
       --ignored-namespaces strings   ignore serviceAccounts from certain namespaces during eval
-      --no-combined-violations       drop combined violations
-      --no-node-violations           drop node violations
-      --no-sa-violations             drop serviceAccount violations
       --only-sas-on-all-nodes        only evaluate serviceAccounts that exist on all nodes
   -s, --severity-threshold string    only evaluate policies with severity >= threshold (default "Low")
       --short                        abbreviate results
+      --violations strings           violations to search for, beside default supports 'user', 'group' and 'all' (default [sa,node,combined])
 
 Global Flags:
   -a, --all-serviceaccounts    collect data on all serviceAccounts, not only those assigned to a pod
@@ -80,6 +78,16 @@ Global Flags:
                             "default:default"
                         ]
                     },
+                ],
+                "users": [ // omitempty
+                    "users-who-violated-the-policy",
+                    "system:kube-controller-manager",
+                    "john@email.com"
+                ],
+                "groups": [ // omitempty
+                    "groups-who-violated-the-policy",
+                    "system:nodes",
+                    "qa-group"
                 ],
             }
         },

--- a/docs/expand.md
+++ b/docs/expand.md
@@ -1,5 +1,5 @@
 # rbac-police expand
-Presents the RBAC permissions of serviceAccounts, pods and nodes in a (more) human-readable format at the expense of storage. Each serviceAccount and node is listed alongside its permissions.
+Presents the RBAC permissions of Kubernetes identities in a (more) human-readable format at the expense of storage. Each identity is listed alongside its permissions.
 
 ## Help
 ```
@@ -28,8 +28,18 @@ Global Flags:
     "metadata": {
         "cluster": "cluster name from the current kubectl context",
         "platform": "eks, gke or empty",
-        "version": "cluster Kubernetes version",
-        "features": ["list of relevant", "feature gates", "and admission controllers"]
+        "version": {
+            "major": "1",
+            "minor": "22",
+            "gitVersion": "v1.22.10-gke.600"
+        },
+        "features": [
+            "list of relevant feature gates and admission controllers,",
+            "currently supports:",
+            "LegacyTokenSecretsReducted",
+            "NodeRestriction",
+            "NodeRestriction1.17",
+        ]
     },
     "serviceAccounts": [
         {
@@ -79,6 +89,30 @@ Global Flags:
                 "kube-system:kube-dns",
             ]
         },
-    ]
+    ],
+    "users": [
+        {
+            "name": "user-name",
+            "roles": [
+                {
+                    "name": "a role / clusterRole assigned to this user",
+                    "effectiveNamespace": "if granted by a roleBinding, namespace where permissions are in effect", // omitempty
+                    "rules": [] // k8s rule format   
+                }
+            ]
+        }
+    ],
+    "groups": [
+        {
+            "name": "group-name",
+            "roles": [
+                {
+                    "name": "a role / clusterRole assigned to this group",
+                    "effectiveNamespace": "if granted by a roleBinding, namespace where permissions are in effect", // omitempty
+                    "rules": [] // k8s rule format   
+                }
+            ]
+        }
+    ],
 }
 ```

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,10 +1,12 @@
 # Policies
-Policies are Rego scripts that detect identities like serviceAccounts possessing RBAC permissions that match certain rule definitions. Policies  produce violations, which have 3 types:
+Policies are [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) scripts that detect identities like service accounts possessing RBAC permissions that match certain rule definitions. Policies produce violations, which can have 5 types:
 - **ServiceAccounts**: Service accounts that violate the policy based on their permissions.
 - **Nodes**: Nodes that violate the policy based on their permissions.
-- **Combined**: Nodes that violate the policy, based on their permissions and those of the serviceAccounts they host.
+- **Users**: Users that violate the policy based on their permissions.
+- **Groups**: Groups that violate the policy based on their permissions.
+- **Combined**: Nodes that violate the policy based on the union of their permissions and the permissions of the service accounts they host.
 
-The policy library at [lib](./lib) includes around 20 policies that identify serviceAccounts, pods and nodes that possess risky permissions, each detecting a different attack path.
+The policy library at [lib](./lib) includes ~20 policies that identify identities that possess risky permissions, each detecting a different attack path.
 
 ## Writing Custom Policies
 Policies are written in Rego, and receive input in the schema produced by `rbac-police collect`, as defined in [collect.md](./collect.md). Policies should define a `describe` rule, at least one violation type they produce, alongside one or two evaluators. Below is the [nodes_proxy](../lib/nodes_proxy.rego) policy, for example.
@@ -14,14 +16,12 @@ package policy
 import data.police_builtins as pb
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes with access to the nodes/proxy subresource can execute code on pods via the Kubelet API"
+  desc := "Identities with access to the nodes/proxy subresource can execute code on pods via the Kubelet API"
   severity := "High"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
-  not pb.blockedByNodeRestriction(owner)
   rule := roles[_].rules[_]
   pb.valueOrWildcard(rule.verbs, "create")
   pb.subresourceOrWildcard(rule.resources, "nodes/proxy")
@@ -32,102 +32,102 @@ evaluateRoles(roles, owner) {
 - A policy must start with `package policy`.
 - A policy can import a number of built-in utility functions from [builtins.rego](../lib/utils/builtins.rego) via `import data.police_builtins`.
 - The `describe` rule defines the description and severity of the policy.
-- The `checkServiceAccounts`, `checkNodes`, and `checkCombined` variables configure which violations the policy produces.
-- The `evaluateRoles` function receives the `roles` of a serviceAccount or node, and based on them determines whether it violates the policy.
+- The `targets` set configures which identities the policy evaluates.
+- The `evaluateRoles` function receives the `roles` of a serviceAccount, node, user, or group and based on them determines whether it violates the policy.
 - Policies can define an `evalute_combined` rule to produce combined violations. See [approve_csrs](../lib/approve_csrs.rego) for an example.
 
 The above options are implemented by a Rego [wrapper](../lib/utils/wrapper.rego). If more control over execution is needed, a policy can be written to run independently, without the wrapper. See the [providerIAM](../lib/providerIAM.rego) policy for an example.
 
 ## Policy Library
 ### [approve_csrs](../lib/approve_csrs.rego)
-- Description: `SAs and nodes that can create and approve certificatesigningrequests can issue arbitrary certificates with cluster admin privileges`
+- Description: `Identities that can create and approve certificatesigningrequests can issue arbitrary certificates with cluster admin privileges`
 - Severity: `Critical`
-- Violation types: `serviceAccounts, nodes, combined`
+- Violation types: `serviceAccounts, nodes, combined, users, groups`
 ### [assign_sa](../lib/assign_sa.rego)
-- Description: `SAs and nodes that can create pods or create, update or patch pod controllers (e.g. DaemonSets, Deployments, Jobs) in privileged namespaces, may assign an admin-equivalent SA to a pod in their control`
+- Description: `Identities that can create pods or create, update or patch pod controllers (e.g. DaemonSets, Deployments, Jobs) in privileged namespaces, may assign an admin-equivalent SA to a pod in their control`
 - Severity: `Critical`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [bind_roles](../lib/bind_roles.rego)
-- Description: `SAs and nodes that can bind clusterrolebindings or bind rolebindings in privileged namespaces can grant admin-equivalent permissions to themselves`
+- Description: `Identities that can bind clusterrolebindings or bind rolebindings in privileged namespaces can grant admin-equivalent permissions to themselves`
 - Severity: `Critical`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [cluster_admin](../lib/cluster_admin.rego)
-- Description: `SAs and nodes with cluster admin privileges pose a significant threat to the cluster if compromised`
+- Description: `Identities with cluster admin privileges pose a significant threat to the cluster if compromised`
 - Severity: `Critical`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [control_webhooks](../lib/control_webhooks.rego)
-- Description: `SAs and nodes that can create, update or patch ValidatingWebhookConfigurations or MutatingWebhookConfigurations can read, and in the case of the latter also mutate, any object admitted to the cluster`
+- Description: `Identities that can create, update or patch ValidatingWebhookConfigurations or MutatingWebhookConfigurations can read, and in the case of the latter also mutate, any object admitted to the cluster`
 - Severity: `High`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [eks_modify_aws_auth](../lib/eks_modify_aws_auth.rego)
-- Description: `SAs and nodes that can modify configmaps in the kube-system namespace on EKS clusters can obtain cluster admin privileges by overwriting the aws-auth configmap`
+- Description: `Identities that can modify configmaps in the kube-system namespace on EKS clusters can obtain cluster admin privileges by overwriting the aws-auth configmap`
 - Severity: `Critical`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [escalate_roles](../lib/escalate_roles.rego)
-- Description: `SAs and nodes that can escalate clusterrole or roles in privileged namespaces are allowed to escalate privileges`
+- Description: `Identities that can escalate clusterrole or roles in privileged namespaces are allowed to escalate privileges`
 - Severity: `Critical`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [impersonate](../lib/impersonate.rego)
-- Description: `SAs and nodes that can impersonate users, groups or other serviceaccounts can escalate privileges by abusing the permissions of the impersonated identity`
+- Description: `Identities that can impersonate users, groups or other serviceaccounts can escalate privileges by abusing the permissions of the impersonated identity`
 - Severity: `Critical`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [issue_token_secrets](../lib/issue_token_secrets.rego)
-- Description: `SAs and nodes that can create or modify secrets in privileged namespaces can issue tokens for admin-equivalent SAs`
+- Description: `Identities that can create or modify secrets in privileged namespaces can issue tokens for admin-equivalent SAs`
 - Severity: `Critical`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [list_secrets](../lib/list_secrets.rego)
-- Description: `SAs and nodes that can list secrets cluster-wide may access confidential information, and in some cases serviceAccount tokens`
-- Severity: `Low`
-- Violation types: `serviceAccounts, nodes`
-### [modify_node_status](../lib/modify_node_status.rego)
-- Description: `SAs and nodes that can modify nodes' status can set or remove labels to affect scheduling constraints enforced via nodeAffinity or nodeSelectors`
-- Severity: `Low`
-- Violation types: `serviceAccounts, nodes`
-### [modify_pod_status](../lib/modify_pod_status.rego)
-- Description: `SAs and nodes that can modify pods' status may match a pod's labels to services' selectors in order to intercept connections to services in the pod's namespace`
-- Severity: `Low`
-- Violation types: `serviceAccounts, nodes`
-### [modify_pods](../lib/modify_pods.rego)
-- Description: `SAs and nodes that can update or patch pods in privileged namespaces can gain code execution on pods that are likely to be powerful`
-- Severity: `High`
-- Violation types: `serviceAccounts, nodes`
-### [modify_service_status_cve_2020_8554](../lib/modify_service_status_cve_2020_8554.rego)
-- Description: `SAs and nodes that can modify services/status may set the status.loadBalancer.ingress.ip field to exploit the unfixed CVE-2020-8554 and launch MiTM attacks against the cluster. Most mitigations for CVE-2020-8554 only prevent ExternalIP services`
+- Description: `Identities that can list secrets cluster-wide may access confidential information, and in some cases serviceAccount tokens`
 - Severity: `Medium`
-- Violation types: `serviceAccounts, nodes`
-### [nodes_proxy](../lib/nodes_proxy.rego)
-- Description: `SAs and nodes with access to the nodes/proxy subresource can execute code on pods via the Kubelet API`
-- Severity: `High`
-- Violation types: `serviceAccounts, nodes`
-### [obtain_token_weak_ns](../lib/obtain_token_weak_ns.rego)
-- Description: `SAs and nodes that can retrieve or issue SA tokens in unprivileged namespaces could potentially obtain tokens with broader permissions over the cluster`
+- Violation types: `serviceAccounts, nodes, users, groups`
+### [modify_node_status](../lib/modify_node_status.rego)
+- Description: `Identities that can modify nodes' status can set or remove labels to affect scheduling constraints enforced via nodeAffinity or nodeSelectors`
 - Severity: `Low`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
+### [modify_pod_status](../lib/modify_pod_status.rego)
+- Description: `Identities that can modify pods' status may match a pod's labels to services' selectors in order to intercept connections to services in the pod's namespace`
+- Severity: `Low`
+- Violation types: `serviceAccounts, nodes, users, groups`
+### [modify_pods](../lib/modify_pods.rego)
+- Description: `Identities that can update or patch pods in privileged namespaces can gain code execution on pods that are likely to be powerful`
+- Severity: `High`
+- Violation types: `serviceAccounts, nodes, users, groups`
+### [modify_service_status_cve_2020_8554](../lib/modify_service_status_cve_2020_8554.rego)
+- Description: `Identities that can modify services/status may set the status.loadBalancer.ingress.ip field to exploit the unfixed CVE-2020-8554 and launch MiTM attacks against the cluster. Most mitigations for CVE-2020-8554 only prevent ExternalIP services`
+- Severity: `Medium`
+- Violation types: `serviceAccounts, nodes, users, groups`
+### [nodes_proxy](../lib/nodes_proxy.rego)
+- Description: `Identities with access to the nodes/proxy subresource can execute code on pods via the Kubelet API`
+- Severity: `High`
+- Violation types: `serviceAccounts, nodes, users, groups`
+### [obtain_token_weak_ns](../lib/obtain_token_weak_ns.rego)
+- Description: `Identities that can retrieve or issue SA tokens in unprivileged namespaces could potentially obtain tokens with broader permissions over the cluster`
+- Severity: `Low`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [pods_ephemeral_ctrs](../lib/pods_ephemeral_ctrs.rego)
-- Description: `SAs and nodes that can update or patch pods/ephemeralcontainers can gain code execution on other pods, and potentially break out to their node by adding an ephemeral container with a privileged securityContext`
+- Description: `Identities that can update or patch pods/ephemeralcontainers can gain code execution on other pods, and potentially break out to their node by adding an ephemeral container with a privileged securityContext`
 - Severity: `High`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [pods_exec](../lib/pods_exec.rego)
-- Description: `SAs and nodes with the create pods/exec permission in privileged namespaces can execute code on pods who are likely to be powerful`
+- Description: `Identities with the create pods/exec permission in privileged namespaces can execute code on pods who are likely to be powerful`
 - Severity: `High`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [providerIAM](../lib/providerIAM.rego)
-- Description: `K8s SAs assigned cloud provider IAM roles may be abused to attack the underlying cloud account (depending on the permissions of the IAM role)`
+- Description: `Kubernetes ServiceAccounts assigned cloud provider IAM roles may be abused to attack the underlying cloud account (depending on the permissions of the IAM role)`
 - Severity: `Low`
 - Violation types: `serviceAccounts`
 ### [rce_weak_ns](../lib/rce_weak_ns.rego)
-- Description: `SAs and nodes that can update or patch pods or create pods/exec in unprivileged namespaces can execute code on existing pods`
+- Description: `Identities that can update or patch pods or create pods/exec in unprivileged namespaces can execute code on existing pods`
 - Severity: `Medium`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [retrieve_token_secrets](../lib/retrieve_token_secrets.rego)
-- Description: `SAs and nodes that can retrieve secrets in privileged namespaces can obtain tokens of admin-equivalent SAs`
+- Description: `Identities that can retrieve secrets in privileged namespaces can obtain tokens of admin-equivalent SAs`
 - Severity: `Critical`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`
 ### [steal_pods](../lib/steal_pods.rego)
-- Description: `SAs and nodes that can delete or evict pods in privileged namespaces and also make other nodes unschedulable can steal powerful pods from other nodes onto a compromised one`
+- Description: `Identities that can delete or evict pods in privileged namespaces and also make other nodes unschedulable can steal powerful pods from other nodes onto a compromised one`
 - Severity: `High`
-- Violation types: `serviceAccounts, nodes, combined`
+- Violation types: `serviceAccounts, nodes, combined, users, groups`
 ### [token_request](../lib/token_request.rego)
-- Description: `SAs and nodes that can create TokenRequests (serviceaccounts/token) in privileged namespaces can issue tokens for admin-equivalent SAs`
+- Description: `Identities that can create TokenRequests (serviceaccounts/token) in privileged namespaces can issue tokens for admin-equivalent SAs`
 - Severity: `Critical`
-- Violation types: `serviceAccounts, nodes`
+- Violation types: `serviceAccounts, nodes, users, groups`

--- a/lib/approve_csrs.rego
+++ b/lib/approve_csrs.rego
@@ -3,12 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can create and approve certificatesigningrequests can issue arbitrary certificates with cluster admin privileges"
+  desc := "Identities that can create and approve certificatesigningrequests can issue arbitrary certificates with cluster admin privileges"
   severity := "Critical" 
 }
-checkCombined := true
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "combined", "users", "groups"}
 
 # https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
 # To create a CSR 

--- a/lib/assign_sa.rego
+++ b/lib/assign_sa.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := sprintf("SAs and nodes that can create pods or create, update or patch pod controllers (e.g. DaemonSets, Deployments, Jobs) in privileged namespaces (%v), may assign an admin-equivalent SA to a pod in their control", [concat(", ", pb.privileged_namespaces)])
+  desc := sprintf("Identities that can create pods or create, update or patch pod controllers (e.g. DaemonSets, Deployments, Jobs) in privileged namespaces (%v), may assign an admin-equivalent SA to a pod in their control", [concat(", ", pb.privileged_namespaces)])
   severity := "Critical"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   some role in roles

--- a/lib/bind_roles.rego
+++ b/lib/bind_roles.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := sprintf("SAs and nodes that can bind clusterrolebindings or bind rolebindings in privileged namespaces (%v) can grant admin-equivalent permissions to themselves", [concat(", ", pb.privileged_namespaces)])
+  desc := sprintf("Identities that can bind clusterrolebindings or bind rolebindings in privileged namespaces (%v) can grant admin-equivalent permissions to themselves", [concat(", ", pb.privileged_namespaces)])
   severity := "Critical"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   some role in roles

--- a/lib/cluster_admin.rego
+++ b/lib/cluster_admin.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes with cluster admin privileges pose a significant threat to the cluster if compromised"
+  desc := "Identities with cluster admin privileges pose a significant threat to the cluster if compromised"
   severity := "Critical"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   some role in roles

--- a/lib/control_webhooks.rego
+++ b/lib/control_webhooks.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can create, update or patch ValidatingWebhookConfigurations or MutatingWebhookConfigurations can read, and in the case of the latter also mutate, any object admitted to the cluster"
+  desc := "Identities that can create, update or patch ValidatingWebhookConfigurations or MutatingWebhookConfigurations can read, and in the case of the latter also mutate, any object admitted to the cluster"
   severity := "High"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   rule := roles[_].rules[_]

--- a/lib/eks_modify_aws_auth.rego
+++ b/lib/eks_modify_aws_auth.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can modify configmaps in the kube-system namespace on EKS clusters can obtain cluster admin privileges by overwriting the aws-auth configmap"
+  desc := "Identities that can modify configmaps in the kube-system namespace on EKS clusters can obtain cluster admin privileges by overwriting the aws-auth configmap"
   severity := "Critical"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   input.metadata.platform == "eks"

--- a/lib/escalate_roles.rego
+++ b/lib/escalate_roles.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := sprintf("SAs and nodes that can escalate clusterrole or roles in privileged namespaces (%v) are allowed to escalate privileges", [concat(", ", pb.privileged_namespaces)])
+  desc := sprintf("Identities that can escalate clusterrole or roles in privileged namespaces (%v) are allowed to escalate privileges", [concat(", ", pb.privileged_namespaces)])
   severity := "Critical"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   some role in roles

--- a/lib/impersonate.rego
+++ b/lib/impersonate.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can impersonate users, groups or other serviceaccounts can escalate privileges by abusing the permissions of the impersonated identity"
+  desc := "Identities that can impersonate users, groups or other serviceaccounts can escalate privileges by abusing the permissions of the impersonated identity"
   severity := "Critical"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   rule := roles[_].rules[_]

--- a/lib/issue_token_secrets.rego
+++ b/lib/issue_token_secrets.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := sprintf("SAs and nodes that can create or modify secrets in privileged namespaces (%v) can issue tokens for admin-equivalent SAs", [concat(", ", pb.privileged_namespaces)])
+  desc := sprintf("Identities that can create or modify secrets in privileged namespaces (%v) can issue tokens for admin-equivalent SAs", [concat(", ", pb.privileged_namespaces)])
   severity := "Critical"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   some role in roles

--- a/lib/list_secrets.rego
+++ b/lib/list_secrets.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can list secrets cluster-wide may access confidential information, and in some cases serviceAccount tokens"
-  severity := "Low"
+  desc := "Identities that can list secrets cluster-wide may access confidential information, and in some cases serviceAccount tokens"
+  severity := "Medium"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   some role in roles

--- a/lib/modify_node_status.rego
+++ b/lib/modify_node_status.rego
@@ -2,14 +2,13 @@ package policy
 import data.police_builtins as pb
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can modify nodes' status can set or remove labels to affect scheduling constraints enforced via nodeAffinity or nodeSelectors"
+  desc := "Identities that can modify nodes' status can set or remove labels to affect scheduling constraints enforced via nodeAffinity or nodeSelectors"
   severity := "Low"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
-  not pb.blockedByNodeRestriction(owner)
+  not pb.nodeRestrictionEnabledAndIsNode(owner)
   rule := roles[_].rules[_]
   pb.subresourceOrWildcard(rule.resources, "nodes/status")
   pb.updateOrPatchOrWildcard(rule.verbs)

--- a/lib/modify_pod_status.rego
+++ b/lib/modify_pod_status.rego
@@ -2,14 +2,13 @@ package policy
 import data.police_builtins as pb
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can modify pods' status may match a pod's labels to services' selectors in order to intercept connections to services in the pod's namespace"
+  desc := "Identities that can modify pods' status may match a pod's labels to services' selectors in order to intercept connections to services in the pod's namespace"
   severity := "Low"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
-  not pb.blockedByNodeRestrictionV117(owner)
+  not pb.nodeRestrictionV117EnabledAndIsNode(owner)
   rule := roles[_].rules[_]
   pb.subresourceOrWildcard(rule.resources, "pods/status")
   pb.updateOrPatchOrWildcard(rule.verbs)

--- a/lib/modify_pods.rego
+++ b/lib/modify_pods.rego
@@ -3,14 +3,13 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := sprintf("SAs and nodes that can update or patch pods in privileged namespaces (%v) can gain code execution on pods that are likely to be powerful", [concat(", ", pb.privileged_namespaces)])
+  desc := sprintf("Identities that can update or patch pods in privileged namespaces (%v) can gain code execution on pods that are likely to be powerful", [concat(", ", pb.privileged_namespaces)])
   severity := "High"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
-  not pb.blockedByNodeRestriction(owner)
+  not pb.nodeRestrictionEnabledAndIsNode(owner)
   some role in roles
   pb.affectsPrivNS(role)
   some rule in role.rules

--- a/lib/modify_service_status_cve_2020_8554.rego
+++ b/lib/modify_service_status_cve_2020_8554.rego
@@ -2,11 +2,10 @@ package policy
 import data.police_builtins as pb
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can modify services/status may set the status.loadBalancer.ingress.ip field to exploit the unfixed CVE-2020-8554 and launch MiTM attacks against the cluster. Most mitigations for CVE-2020-8554 only prevent ExternalIP services"
+  desc := "Identities that can modify services/status may set the status.loadBalancer.ingress.ip field to exploit the unfixed CVE-2020-8554 and launch MiTM attacks against the cluster. Most mitigations for CVE-2020-8554 only prevent ExternalIP services"
   severity := "Medium"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   rule := roles[_].rules[_]

--- a/lib/nodes_proxy.rego
+++ b/lib/nodes_proxy.rego
@@ -2,14 +2,13 @@ package policy
 import data.police_builtins as pb
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes with access to the nodes/proxy subresource can execute code on pods via the Kubelet API"
+  desc := "Identities with access to the nodes/proxy subresource can execute code on pods via the Kubelet API"
   severity := "High"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
-  not pb.blockedByNodeRestriction(owner)
+  not pb.nodeRestrictionEnabledAndIsNode(owner)
   rule := roles[_].rules[_]
   pb.valueOrWildcard(rule.verbs, "create")
   pb.subresourceOrWildcard(rule.resources, "nodes/proxy")

--- a/lib/obtain_token_weak_ns.rego
+++ b/lib/obtain_token_weak_ns.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can retrieve or issue SA tokens in unprivileged namespaces could potentially obtain tokens with broader permissions over the cluster"
+  desc := "Identities that can retrieve or issue SA tokens in unprivileged namespaces could potentially obtain tokens with broader permissions over the cluster"
   severity := "Low"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   some role in roles
@@ -28,7 +27,7 @@ ruleCanAcquireToken(rule, ruleOwner) {
   pb.valueOrWildcard(rule.resources, "secrets")
   canAbuseSecretsForToken(rule.verbs)
 } {
-  not pb.blockedByNodeRestriction(ruleOwner)
+  not pb.nodeRestrictionEnabledAndIsNode(ruleOwner)
   pb.subresourceOrWildcard(rule.resources, "serviceaccounts/token")
   pb.valueOrWildcard(rule.verbs, "create")
 }

--- a/lib/pods_ephemeral_ctrs.rego
+++ b/lib/pods_ephemeral_ctrs.rego
@@ -2,14 +2,13 @@ package policy
 import data.police_builtins as pb
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can update or patch pods/ephemeralcontainers can gain code execution on other pods, and potentially break out to their node by adding an ephemeral container with a privileged securityContext"
+  desc := "Identities that can update or patch pods/ephemeralcontainers can gain code execution on other pods, and potentially break out to their node by adding an ephemeral container with a privileged securityContext"
   severity := "High"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
-  not pb.blockedByNodeRestriction(owner)
+  not pb.nodeRestrictionEnabledAndIsNode(owner)
   rule := roles[_].rules[_]
   pb.valueOrWildcard(rule.apiGroups, "")
   pb.subresourceOrWildcard(rule.resources, "pods/ephemeralcontainers")

--- a/lib/pods_exec.rego
+++ b/lib/pods_exec.rego
@@ -3,14 +3,13 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := sprintf("SAs and nodes with the create pods/exec permission in privileged namespaces (%v) can execute code on pods who are likely to be powerful", [concat(", ", pb.privileged_namespaces)])
+  desc := sprintf("Identities with the create pods/exec permission in privileged namespaces (%v) can execute code on pods who are likely to be powerful", [concat(", ", pb.privileged_namespaces)])
   severity := "High"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
-  not pb.blockedByNodeRestriction(owner)
+  not pb.nodeRestrictionEnabledAndIsNode(owner)
   some role in roles
   pb.affectsPrivNS(role)
   some rule in role.rules

--- a/lib/providerIAM.rego
+++ b/lib/providerIAM.rego
@@ -1,13 +1,15 @@
 package policy
 import data.police_builtins as pb
+import data.config
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "K8s SAs assigned cloud provider IAM roles may be abused to attack the underlying cloud account (depending on the permissions of the IAM role)"
+  desc := "Kubernetes ServiceAccounts assigned cloud provider IAM roles may be abused to attack the underlying cloud account (depending on the permissions of the IAM role)"
   severity := "Low"
 }
 
 main[{"violations": violation}] {
+  config.evalSaViolations
   violation := {"serviceAccounts": saViolations}
 } 
 

--- a/lib/rce_weak_ns.rego
+++ b/lib/rce_weak_ns.rego
@@ -3,15 +3,14 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := "SAs and nodes that can update or patch pods or create pods/exec in unprivileged namespaces can execute code on existing pods"
+  desc := "Identities that can update or patch pods or create pods/exec in unprivileged namespaces can execute code on existing pods"
   severity := "Medium"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 # This runs modify_pods and pods_exec but for weak namespaces
 evaluateRoles(roles, owner) {
-  not pb.blockedByNodeRestriction(owner)
+  not pb.nodeRestrictionEnabledAndIsNode(owner)
   some role in roles
   not pb.affectsPrivNS(role)
   some rule in role.rules

--- a/lib/retrieve_token_secrets.rego
+++ b/lib/retrieve_token_secrets.rego
@@ -3,11 +3,10 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := sprintf("SAs and nodes that can retrieve secrets in privileged namespaces (%v) can obtain tokens of admin-equivalent SAs", [concat(", ", pb.privileged_namespaces)])
+  desc := sprintf("Identities that can retrieve secrets in privileged namespaces (%v) can obtain tokens of admin-equivalent SAs", [concat(", ", pb.privileged_namespaces)])
   severity := "Critical"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
   not pb.legacyTokenSecretsReducted

--- a/lib/token_request.rego
+++ b/lib/token_request.rego
@@ -3,14 +3,13 @@ import data.police_builtins as pb
 import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
-  desc := sprintf("SAs and nodes that can create TokenRequests (serviceaccounts/token) in privileged namespaces (%v) can issue tokens for admin-equivalent SAs", [concat(", ", pb.privileged_namespaces)])
+  desc := sprintf("Identities that can create TokenRequests (serviceaccounts/token) in privileged namespaces (%v) can issue tokens for admin-equivalent SAs", [concat(", ", pb.privileged_namespaces)])
   severity := "Critical"
 }
-checkServiceAccounts := true
-checkNodes := true
+targets := {"serviceAccounts", "nodes", "users", "groups"}
 
 evaluateRoles(roles, owner) {
-  not pb.blockedByNodeRestriction(owner)
+  not pb.nodeRestrictionEnabledAndIsNode(owner)
   some role in roles
   pb.affectsPrivNS(role)
   some rule in role.rules

--- a/lib/utils/builtins.rego
+++ b/lib/utils/builtins.rego
@@ -91,7 +91,7 @@ getOrListOrWildcard(verbs) {
 
 # True if by any mean, @rule is permitted to overwrite the SA of a pod
 ruleCanControlPodSa(rule, ruleOwner) {
-  not blockedByNodeRestriction(ruleOwner)
+  not nodeRestrictionEnabledAndIsNode(ruleOwner)
   valueOrWildcard(rule.verbs, "create")
   valueOrWildcard(rule.resources, "pods")
   valueOrWildcard(rule.apiGroups, "")
@@ -197,13 +197,13 @@ NodeRestrictionV117 := true {
 }
 
 # Permission owner is a node and NodeRestriction is enabled
-blockedByNodeRestriction(permissionOwner) {
+nodeRestrictionEnabledAndIsNode(permissionOwner) {
   NodeRestriction
   permissionOwner == "node"
 }
 
 # Permission owner is a node and NodeRestriction v1.17 is enabled
-blockedByNodeRestrictionV117(permissionOwner) {
+nodeRestrictionV117EnabledAndIsNode(permissionOwner) {
   NodeRestrictionV117
   permissionOwner == "node"
 }

--- a/pkg/collect/collect.go
+++ b/pkg/collect/collect.go
@@ -46,6 +46,8 @@ func Collect(collectConfig CollectConfig) *CollectResult {
 		Metadata:        *metadata,
 		ServiceAccounts: rbacDb.ServiceAccounts,
 		Nodes:           rbacDb.Nodes,
+		Users:           rbacDb.Users,
+		Groups:          rbacDb.Groups,
 		Roles:           rbacDb.Roles,
 	}
 }

--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -70,7 +70,7 @@ func Eval(policyPath string, collectResult collect.CollectResult, evalConfig Eva
 	}
 
 	// Prepare configuration for policies
-	policyConfig := bytes.NewBufferString(fmt.Sprintf(`{
+	policyConfig := fmt.Sprintf(`{
 		"config": {
 			"evalSaViolations": %t,
 			"evalNodeViolations": %t,
@@ -78,7 +78,7 @@ func Eval(policyPath string, collectResult collect.CollectResult, evalConfig Eva
 			"evalUserViolations": %t,
 			"evalGroupViolations": %t
 		}
-	}`, evalConfig.SaViolations, evalConfig.NodeViolations, evalConfig.CombinedViolations, evalConfig.UserViolations, evalConfig.GroupViolations))
+	}`, evalConfig.SaViolations, evalConfig.NodeViolations, evalConfig.CombinedViolations, evalConfig.UserViolations, evalConfig.GroupViolations)
 
 	// Run policies against input json
 	var policyResults PolicyResults
@@ -113,7 +113,7 @@ func Eval(policyPath string, collectResult collect.CollectResult, evalConfig Eva
 }
 
 // Runs a Rego policy on @rbacJson
-func runPolicy(policyFile string, rbacJson interface{}, policyConfig *bytes.Buffer, evalConfig EvalConfig) (*PolicyResult, error) {
+func runPolicy(policyFile string, rbacJson interface{}, policyConfig string, evalConfig EvalConfig) (*PolicyResult, error) {
 	policyResult := PolicyResult{PolicyFile: policyFile}
 
 	// Get policy description & severity
@@ -172,7 +172,7 @@ func describePolicy(policyFile string) *DescribeRegoResult {
 }
 
 // Evaluate policy on @input, return violations
-func evaluatePolicy(policyFile string, input interface{}, policyConfig *bytes.Buffer, evalConfig EvalConfig) (*Violations, error) {
+func evaluatePolicy(policyFile string, input interface{}, policyConfig string, evalConfig EvalConfig) (*Violations, error) {
 	var (
 		foundViolations = false
 		violations      Violations
@@ -197,7 +197,7 @@ func evaluatePolicy(policyFile string, input interface{}, policyConfig *bytes.Bu
 	}
 
 	// Manually create storage in-memory, write policyConfig into it, and set up a writable transaction for Load()
-	store := inmem.NewFromReader(policyConfig)
+	store := inmem.NewFromReader(bytes.NewBufferString(policyConfig))
 	txn, err := store.NewTransaction(ctx, storage.WriteParams)
 	if err != nil {
 		log.Errorf("evaluatePolicy: error preparing transaction for %v with %v\n", policyFile, err)

--- a/pkg/eval/types.go
+++ b/pkg/eval/types.go
@@ -2,13 +2,15 @@ package eval
 
 // Configuration for Expand()
 type EvalConfig struct {
-	SeverityThreshold    string
-	OnlySasOnAllNodes    bool
-	IgnoredNamespaces    []string
-	NoSaViolations       bool
-	NoNodeViolations     bool
-	NoCombinedViolations bool
-	DebugMode            bool
+	SeverityThreshold  string
+	OnlySasOnAllNodes  bool
+	IgnoredNamespaces  []string
+	DebugMode          bool
+	SaViolations       bool
+	NodeViolations     bool
+	CombinedViolations bool
+	UserViolations     bool
+	GroupViolations    bool
 }
 
 // Evalaution results for policies
@@ -52,6 +54,8 @@ type Violations struct {
 	ServiceAccounts []ServiceAccountViolation `json:"serviceAccounts,omitempty" mapstructure:"serviceAccounts"`
 	Nodes           []string                  `json:"nodes,omitempty"`
 	Combined        []CombinedViolation       `json:"combined,omitempty"`
+	Users           []string                  `json:"users,omitempty"`
+	Groups          []string                  `json:"groups,omitempty"`
 }
 
 // Policy violations, abbreviated
@@ -59,6 +63,8 @@ type AbbreviatedViolations struct {
 	ServiceAccounts []string            `json:"serviceAccounts,omitempty" mapstructure:"serviceAccounts"`
 	Nodes           []string            `json:"nodes,omitempty"`
 	Combined        []CombinedViolation `json:"combined,omitempty"`
+	Users           []string            `json:"users,omitempty"`
+	Groups          []string            `json:"groups,omitempty"`
 }
 
 // Violation from a serviceAccount
@@ -86,6 +92,8 @@ type EvalRegoResult struct {
 	ServiceAccounts []ServiceAccountViolation `json:"serviceAccounts,omitempty" mapstructure:"serviceAccounts"`
 	Nodes           []string                  `json:"nodes,omitempty"`
 	Combined        []CombinedViolation       `json:"combined,omitempty"`
+	Users           []string                  `json:"users,omitempty"`
+	Groups          []string                  `json:"groups,omitempty"`
 }
 
 // Below severity threshold error

--- a/pkg/expand/expand.go
+++ b/pkg/expand/expand.go
@@ -11,6 +11,7 @@ func Expand(collectResult collect.CollectResult) *ExpandResult {
 		Metadata: collectResult.Metadata,
 	}
 
+	// Add serviceaccounts
 	for _, serviceAccount := range collectResult.ServiceAccounts {
 		expandedSA := ExpandedServiceAccount{
 			Name:        serviceAccount.Name,
@@ -22,6 +23,7 @@ func Expand(collectResult collect.CollectResult) *ExpandResult {
 		expandResult.ServiceAccounts = append(expandResult.ServiceAccounts, expandedSA)
 	}
 
+	// Add nodes
 	for _, node := range collectResult.Nodes {
 		expandedNode := ExpandedNode{
 			Name:            node.Name,
@@ -29,6 +31,24 @@ func Expand(collectResult collect.CollectResult) *ExpandResult {
 		}
 		expandedNode.Roles = expandRoleRefs(node.Roles, collectResult.Roles)
 		expandResult.Nodes = append(expandResult.Nodes, expandedNode)
+	}
+
+	// Add users
+	for _, user := range collectResult.Users {
+		expandedUser := ExpandedNamedEntry{
+			Name:  user.Name,
+			Roles: expandRoleRefs(user.Roles, collectResult.Roles),
+		}
+		expandResult.Users = append(expandResult.Users, expandedUser)
+	}
+
+	// Add groups
+	for _, group := range collectResult.Groups {
+		expandedGroup := ExpandedNamedEntry{
+			Name:  group.Name,
+			Roles: expandRoleRefs(group.Roles, collectResult.Roles),
+		}
+		expandResult.Groups = append(expandResult.Groups, expandedGroup)
 	}
 
 	return &expandResult

--- a/pkg/expand/types.go
+++ b/pkg/expand/types.go
@@ -11,6 +11,8 @@ type ExpandResult struct {
 	Metadata        collect.ClusterMetadata  `json:"metadata"`
 	ServiceAccounts []ExpandedServiceAccount `json:"serviceAccounts"`
 	Nodes           []ExpandedNode           `json:"nodes"`
+	Users           []ExpandedNamedEntry     `json:"users"`
+	Groups          []ExpandedNamedEntry     `json:"groups"`
 }
 
 // RBAC permissions of a serviceAccount
@@ -27,6 +29,12 @@ type ExpandedNode struct {
 	Name            string         `json:"name"`
 	Roles           []ExpandedRole `json:"roles"`
 	ServiceAccounts []string       `json:"serviceAccounts"`
+}
+
+// RBAC permissions of an identity denoted by name, like a user or a group
+type ExpandedNamedEntry struct {
+	Name  string         `json:"name"`
+	Roles []ExpandedRole `json:"roles"`
 }
 
 // A role granted in @EffectiveNamespace

--- a/utils/update_policy_to_use_targets.py
+++ b/utils/update_policy_to_use_targets.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Updates a policy to use the new 'targets' set introduced in v1.1.0 instead of the old 'checkXXX' variables
+# Usage: update_policy_to_use_targets.py <policy-file-path> <output-path>"
+from sys import argv
+import regex
+
+def main(policy_path, output_path):
+    updated_policy = []
+    with open(policy_path, "r") as policy_file:
+        targets = []
+        line_to_insert_targets = -1
+
+        # Iterate policy files
+        for i, line in enumerate(policy_file):
+            # Exit if policy is already in the new format
+            if defined_as_rego_set(line, "targets"):
+                print(f"[+] Policy '{policy_path}' already defines a 'targets' set, it's in the new format")
+                return 
+            # Add serviceAccounts to targets if checkServiceAccounts is defined
+            elif defined_as_rego_true(line, "checkServiceAccounts"):
+                if line_to_insert_targets < 0: 
+                    line_to_insert_targets = i
+                targets.append("serviceAccounts")
+            # Add nodes to targets if checkNodes is defined
+            elif defined_as_rego_true(line, "checkNodes"):
+                if line_to_insert_targets < 0: 
+                    line_to_insert_targets = i
+                targets.append("nodes")    
+            # Add combined to targets if checkCombined is defined
+            elif defined_as_rego_true(line, "checkCombined"):
+                if line_to_insert_targets < 0: 
+                    line_to_insert_targets = i
+                targets.append("combined")
+            # Add all others lines to new policy
+            else: 
+                updated_policy.append(line) 
+        # If couldn't find any checkXXX variable, exit
+        if line_to_insert_targets == -1:
+                print(f"[!] Policy '{policy_path}' doesn't seem like a wrapped rbac-police policy as it doesn't define a 'checkServiceAccounts', 'checkNodes' or 'checkCombined' variable")
+                return
+        # Inject the 'targets' set into the new policy
+        targets_str = 'targets := {"' + '", "'.join(targets) + '"}\n'
+        updated_policy.insert(line_to_insert_targets, targets_str)
+
+        # Write updated policy to output_path
+        with open(output_path, "w") as output_file:
+            output_file.write("".join(updated_policy))
+        print(f"[+] Done, new policy at {output_path}")
+
+# Returns true if @set_name is defined as a Rego set in @line
+def defined_as_rego_set(line, set_name):
+    return regex.match(f'\s*{set_name}\s*:?=\s*\{{.*\}}', line) != None
+
+# Returns true if @variable is a Rego variable set to true in @line
+def defined_as_rego_true(line, variable):
+    return regex.match(f'\s*{variable}\s*:?=\s*true', line) != None
+
+if __name__ == "__main__":
+    if len(argv) < 3:
+        print(f"[+] Usage: {argv[0]} <policy-file-path> <output-path>")
+        exit(1)
+    policy_path = argv[1]
+    output_path = argv[2]
+
+    main(policy_path, output_path)


### PR DESCRIPTION
- Collect user & group roles; allow policies to produce user & group violations
- Minor but **BREAKING** change to the policy format: new `targets` set instead of `checkXXX` variables. Users can use `utils/update_policy_to_use_targets.py` to update custom policies.
- Replace `--no-XX-violations` flags (**BREAKING**) with new `--violations` flag
- Slight perf improvements