### PR TITLE
fix: reference utils files relative to policy lib directory

### DIFF
--- a/pkg/eval/wrapper.go
+++ b/pkg/eval/wrapper.go
@@ -5,11 +5,12 @@ import (
 )
 
 const (
-	wrapperFile = "lib/utils/wrapper.rego" // TODO: move elsewhere / make configurable / go-bindata
+	wrapperFileSuffix = "utils/wrapper.rego" // TODO: move elsewhere / make configurable / go-bindata
 )
 
 var (
-	wrappedPattern = `(?m)^\s*main\s*\[\s*\{.*\}\s*\].*$`
+	wrapperFilePath string
+	wrappedPattern  = `(?m)^\s*main\s*\[\s*\{.*\}\s*\].*$`
 )
 
 // Checks if policy needs wrapping (doesn't define main rule)


### PR DESCRIPTION
## Description

The location of utils rego files are currently hardcoded. If we move the lib folder to outside the current directory, the utils rego files cannot be found.

## Motivation and Context

This PR locates the utils rego files relative to the lib path specified on the CLI.

## How Has This Been Tested?

I have built the binary with changes and tested locally.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
